### PR TITLE
2.0.0rc2 - Updates to enable PyPi hosting.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,37 +6,9 @@ on:
   release:
     types: [ published ]
 
-env:
-  REGISTRY: "lhr.ocir.io/lr3yhdniv6gu"
-
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository ${{ github.repository }}
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract repository name
-        id: repo-name
-        # Strip the owner and `/` from the repo env var
-        run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
-
-      - name: Login to OCIR in gpasltd
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.OCI_USERNAME_GPASLTD }}
-          password: ${{ secrets.OCI_TOKEN_GPASLTD }}
-
-      - name: Build and push to gpasltd OCR
-        id: build_and_push_gpas_ltd
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          file: Dockerfile
-          tags:
-            "${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}:${{ github.event.release.tag_name }}"
+    uses: EIT-Pathogena/common-workflows/.github/workflows/build-and-push-to-ocir.yml@main
+    with:
+      repository: ${{ github.repository }}
+      image_tag: ${{ github.event.release.tag_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0rc2] - 2024-07-24
+
+### Added
+
+- `hostile-eit` entrypoint can be used, not expected to be picked up, added just in case.
+
+### Changed
+
+- Project references to `hostile-eit` to enable pushing to PyPi without conflicting with
+  existing naming, `hostile` is still the entrypoint.
+- GitHub workflow attempts to use an external re-usable action.
+
 ## [2.0.0rc1] - 2024-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Bedtools). Hostile is tested with Ubuntu Linux 22.04, MacOS 12, and under WSL fo
 **Conda/mamba**
 
 ```bash
-conda create -y -n hostile -c conda-forge -c bioconda hostile
-conda activate hostile
+conda create -y -n hostile_eit -c conda-forge -c bioconda hostile_eit
+conda activate hostile_eit
 ```
 
 **Docker**
@@ -301,9 +301,9 @@ Bede Constantinides, Martin Hunt, Derrick W Crook, Hostile: accurate decontamina
 ```bash
 git clone https://github.com/EIT-Pathogena/hostile-eit
 .git
-cd hostile
+cd hostile-eit
 conda env create -y -f environment.yml
-conda activate hostile
+conda activate hostile-eit
 pip install --editable '.[dev]'
 pytest
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: hostile
+name: hostile-eit
 channels:
   - conda-forge
   - bioconda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "hostile"
+name = "hostile-eit"
 authors = [
     { name = "Jay Dhillon", email = "jdhillon@eit.org" },
     { name = "Bede Constantinides", email = "b@bede.im" },
@@ -28,7 +28,8 @@ dependencies = [
 Home = "https://github.com/EIT-Pathogena/hostile-eit"
 
 [project.scripts]
-hostile = "hostile.cli:main"
+hostile = "hostile_eit.cli:main"
+hostile-eit = "hostile_eit.cli:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/hostile_eit/__init__.py
+++ b/src/hostile_eit/__init__.py
@@ -1,3 +1,3 @@
 """Accurate host read removal"""
 
-__version__ = "2.0.0rc1"
+__version__ = "2.0.0rc2"

--- a/src/hostile_eit/aligner.py
+++ b/src/hostile_eit/aligner.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
-from hostile import util
+from hostile_eit import util
 
 
 @dataclass

--- a/src/hostile_eit/cli.py
+++ b/src/hostile_eit/cli.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 import defopt
 
-from hostile import lib, util
+from hostile_eit import lib, util
 
 
 class ALIGNER(Enum):
@@ -129,7 +129,7 @@ def fetch(
     list: bool = False,
 ) -> None:
     """
-    Download and cache indexes from object storage for use with hostile clean
+    Download and cache indexes from object storage for use with hostile_eit clean
 
     :arg name: name of index to download
     :arg aligner: aligner(s) for which to download an index

--- a/src/hostile_eit/lib.py
+++ b/src/hostile_eit/lib.py
@@ -5,8 +5,8 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
-from hostile import util, __version__
-from hostile.aligner import ALIGNER
+from hostile_eit import util, __version__
+from hostile_eit.aligner import ALIGNER
 
 
 logging.basicConfig(

--- a/src/hostile_eit/util.py
+++ b/src/hostile_eit/util.py
@@ -33,7 +33,7 @@ CWD = Path.cwd()
 CACHE_DIR = (
     Path(os.environ.get("HOSTILE_CACHE_DIR", ""))
     if os.environ.get("HOSTILE_CACHE_DIR")
-    else Path(user_data_dir("hostile_eit-eit", "Bede Constantinides"))
+    else Path(user_data_dir("hostile-eit", "Bede Constantinides"))
 )
 CPU_COUNT = multiprocessing.cpu_count()
 THREADS = choose_default_thread_count(CPU_COUNT)

--- a/src/hostile_eit/util.py
+++ b/src/hostile_eit/util.py
@@ -33,7 +33,7 @@ CWD = Path.cwd()
 CACHE_DIR = (
     Path(os.environ.get("HOSTILE_CACHE_DIR", ""))
     if os.environ.get("HOSTILE_CACHE_DIR")
-    else Path(user_data_dir("hostile-eit", "Bede Constantinides"))
+    else Path(user_data_dir("hostile_eit-eit", "Bede Constantinides"))
 )
 CPU_COUNT = multiprocessing.cpu_count()
 THREADS = choose_default_thread_count(CPU_COUNT)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from hostile import lib
+from hostile_eit import lib
 
 data_dir = Path("tests/data")
 out_dir = Path("test_data")


### PR DESCRIPTION
Upon going to upload to PyPi, I realised this would upload to hostile which of course already exists!

Changed the code references so that pyproject.toml is correctly used, the entrypoint is still the same hostile --version etc.

Also first pass at a reusable GitHub workflow: https://github.com/EIT-Pathogena/common-workflows/blob/main/.github/workflows/build-and-push-to-ocir.yml